### PR TITLE
Forum colors fix

### DIFF
--- a/src/modules/main/chat/global.less
+++ b/src/modules/main/chat/global.less
@@ -1,5 +1,4 @@
 div[class*="chat_"] {
-
     // New messages bar at the top.
     div[class*="newMessagesBar"],
     div[class*="jumpToPresentBar_"] {
@@ -20,6 +19,10 @@ div[class*="chat_"] {
     }
 
     >div[class*="content_"] {
+        >div[class*="container_"] {
+            border: none !important;
+        }
+
         div[class*="divider_"] {
             border-color: var(--dnome-border);
             margin-left: 0rem;

--- a/src/modules/main/forum.less
+++ b/src/modules/main/forum.less
@@ -1,5 +1,7 @@
 // Forums
-div[data-list-id*="forum-channel-list_"][class*="list_"][class*="scrollerBase_"] {
+div[data-list-id*="forum-channel-list-"][class*="list_"][class*="scrollerBase_"] {
+    background-color: var(--dnome-scroll-bg);
+
     div[class*="headerRow_"] {
         >div[class*="mainCard_"] {
             border-radius: var(--dnome-border-small);


### PR DESCRIPTION
This is a supplementary fix for issue #11.

The forum colors were not being applied due to the last character of the custom attribute value needing to match a dash, instead of an underscore.

I only have tested it with [WebCord](https://github.com/SpacingBat3/WebCord), so it might need some feedback from others.